### PR TITLE
Fix escaping of names in graphviz examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ Just `dot` is supported, but any of the other graphviz tools would be easy to ad
 ~~~markdown
 ```dot process
 digraph {
-    processed -> graph
+    "processed" -> "graph"
 }
 ```
 ~~~
@@ -49,7 +49,7 @@ digraph {
 ~~~markdown
 ```dot process Named Graph
 digraph {
-    processed -> graph
+    "processed" -> "graph"
 }
 ```
 ~~~
@@ -68,7 +68,7 @@ digraph {
 ~~~markdown
 ```dot
 digraph {
-    processed -> graph
+    "processed" -> "graph"
 }
 ```
 ~~~
@@ -77,7 +77,7 @@ digraph {
 ~~~markdown
 ```dot
 digraph {
-    processed -> graph
+    "processed" -> "graph"
 }
 ```
 ~~~


### PR DESCRIPTION
The Readme examples can not be used with graphviz. It will result in the following error:
```
syntax error in line 2 near 'graph'
```
These change properly escapes the name of the nodes in the graph