### PR TITLE
v0.1.1 support the same parser as mdBook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-graphviz"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-graphviz"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Dylan Owen <dyltotheo@gmail.com>"]
 description = "mdbook preprocessor to add graphviz support"
 readme = "Readme.md"


### PR DESCRIPTION
I should have always been using the same cmark parser that mdbook uses.