### PR TITLE
Ignore draft chapters

### DIFF
--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -41,7 +41,10 @@ impl Preprocessor for GraphvizPreprocessor {
             // only continue editing the book if we don't have any errors
             if error.is_ok() {
                 if let BookItem::Chapter(ref mut chapter) = item {
-                    let path = chapter.path.as_ref().unwrap();
+                    let path = match chapter.path.as_ref() {
+                        Some(path) => path,
+                        None => return,
+                    };
                     let mut full_path = src_dir.join(path);
 
                     // remove the chapter filename


### PR DESCRIPTION
mdbook-graphviz panics when there are [draft chapters](https://rust-lang.github.io/mdBook/format/summary.html) and the path is empty.
```
2021-09-02 01:22:06 [INFO] (mdbook::book): Book building has started
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/preprocessor.rs:44:54
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This change ignores chapters where the path is None.