### PR TITLE
Update mdbook, pulldown-cmark and pulldown-cmark-to-cmark dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,9 +758,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mdbook"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0651782b4cc514c3f98c0acf9b5af1101a735bbe1ac6852bb1a90cb91bdf0ed4"
+checksum = "f6e77253c46a90eb7e96b2807201dab941a4db5ea05eca5aaaf7027395f352b3"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -764,7 +775,7 @@ dependencies = [
  "log",
  "memchr",
  "notify",
- "open",
+ "opener",
  "pulldown-cmark",
  "regex",
  "serde",
@@ -774,6 +785,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "topological-sort",
  "warp",
 ]
 
@@ -964,20 +976,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "open"
-version = "1.7.1"
+name = "opener"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea7a30d6b81a2423cc59c43554880feff7b57d12916f231a79f8d6d9470201"
+checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
 dependencies = [
- "pathdiff",
+ "bstr",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "percent-encoding"
@@ -1133,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1145,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "5.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32accf4473121d8c0b508ca5673363703762d6cc59cf25af1df48f653346f736"
+checksum = "2d85e607de0249c2b5041e38de8684b00b62a64edee60bfcd85c153031a9d658"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -1283,6 +1289,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1615,6 +1627,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "topological-sort"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mdbook = "0.4"
+mdbook = "^0.4.14"
 clap = "2.33"
 serde_json = "1.0"
-pulldown-cmark = "0.7"
-pulldown-cmark-to-cmark = "5.0"
+pulldown-cmark = "0.8"
+pulldown-cmark-to-cmark = "7.1"
 
 lazy_static = "1.4.0"
 regex = "1.3"

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -80,7 +80,7 @@ impl<R: GraphvizRenderer> Graphviz<R> {
         let mut graphviz_block_builder: Option<GraphvizBlockBuilder> = None;
         let mut image_index = 0;
 
-        let event_results: Result<Vec<Vec<Event>>> = new_cmark_parser(&chapter.content)
+        let event_results: Result<Vec<Vec<Event>>> = new_cmark_parser(&chapter.content, false)
             .map(|e| {
                 if let Some(mut builder) = graphviz_block_builder.take() {
                     match e {


### PR DESCRIPTION
This fixes issue #17, which would cause `cargo build mdbook-graphviz` to
fail. This brings packages up to their current latest versions:

* pulldown-cmark: From 0.7 to 0.8
* pulldown-cmark-to-cmark: From 5.0 to 7.1
* mdbook: From 0.4.x to ^0.4.14

The mdbook update is required because this version added a parameter
named `curly_quotes` to the `new_cmark_parser` function. I elected to
set this parameter to `false`, as there does not appear to be
configuration in the mdbook package for this yet. Presumably, that will
come in the future and it should be copied into this repository.