### PR TITLE
Allow specifying custom graphviz arguments

### DIFF
--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -302,7 +302,10 @@ mod test {
 
     #[async_trait]
     impl GraphvizRenderer for NoopRenderer {
-        async fn render_graphviz<'a>(_args: &'a [&'a str], block: GraphvizBlock) -> Result<Vec<Event<'a>>> {
+        async fn render_graphviz<'a>(
+            _args: &'a [&'a str],
+            block: GraphvizBlock,
+        ) -> Result<Vec<Event<'a>>> {
             let file_name = block.file_name();
             let output_path = block.output_path();
             let GraphvizBlock {
@@ -447,7 +450,10 @@ digraph Test {
     struct SleepyRenderer;
     #[async_trait]
     impl GraphvizRenderer for SleepyRenderer {
-        async fn render_graphviz<'a>(_args: &'a [&'a str], _block: GraphvizBlock) -> Result<Vec<Event<'a>>> {
+        async fn render_graphviz<'a>(
+            _args: &'a [&'a str],
+            _block: GraphvizBlock,
+        ) -> Result<Vec<Event<'a>>> {
             tokio::time::sleep(SLEEP_DURATION).await;
             Ok(vec![Event::Text("".into())])
         }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -12,7 +12,10 @@ use tokio::io::AsyncWriteExt;
 
 #[async_trait]
 pub trait GraphvizRenderer {
-    async fn render_graphviz<'a>(args: &'a [&'a str], block: GraphvizBlock) -> Result<Vec<Event<'a>>>;
+    async fn render_graphviz<'a>(
+        args: &'a [&'a str],
+        block: GraphvizBlock,
+    ) -> Result<Vec<Event<'a>>>;
 }
 
 pub struct CLIGraphviz;
@@ -23,10 +26,7 @@ impl GraphvizRenderer for CLIGraphviz {
         args: &'a [&'a str],
         GraphvizBlock { code, .. }: GraphvizBlock,
     ) -> Result<Vec<Event<'a>>> {
-        let output = call_graphviz(args, &code)
-            .await?
-            .wait_with_output()
-            .await?;
+        let output = call_graphviz(args, &code).await?.wait_with_output().await?;
         if output.status.success() {
             let graph_svg = String::from_utf8(output.stdout)?;
 
@@ -44,7 +44,10 @@ pub struct CLIGraphvizToFile;
 
 #[async_trait]
 impl GraphvizRenderer for CLIGraphvizToFile {
-    async fn render_graphviz<'a>(args: &'a [&'a str], block: GraphvizBlock) -> Result<Vec<Event<'a>>> {
+    async fn render_graphviz<'a>(
+        args: &'a [&'a str],
+        block: GraphvizBlock,
+    ) -> Result<Vec<Event<'a>>> {
         let file_name = block.file_name();
         let output_path = block.output_path();
         let GraphvizBlock {


### PR DESCRIPTION
This should fix #88.

It reads the `arguments` option from the config file (or defaults to `["-Tsvg"]`) and passes it down to `call_graphviz`.
For example:
```toml
[preprocessor.graphviz]
arguments = ["-Tsvg", "-Grankdir=LR"]
```

Note: I haven't had much experience with lifetimes, so I trusted the compiler more or less.