### PR TITLE
Add class to output div

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,10 +42,11 @@ digraph {
 #### Output
 
 ~~~markdown
-<div><svg>...</svg></div>
-
-
+<div class="mdbook-graphviz-output"><svg>...</svg></div>
 ~~~
+
+The `class` attribute gives you the chance to apply a common style to all
+the output images (e.g. [center all of them](https://github.com/dylanowen/mdbook-graphviz/issues/26)).
 
 #### Rendered
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -135,7 +135,7 @@ fn format_output(output: String) -> String {
     let output = NEWLINES_RE.replace_all(&output, "");
     let output = output.trim();
 
-    format!("<div>{output}</div>")
+    format!("<div class=\"mdbook-graphviz-output\">{output}</div>")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add class to the output `div` in order to easily add a common style among all the produced outputs (e.g. center all the output svg images - #26).